### PR TITLE
Add instructions for accessing the workspaces HTML

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,11 +54,13 @@ This is recommended template for the HTML file for the workspaces:
   <body>
     <div id="app"></div>
     <!-- you might need to change the js path depending on your configuration -->
-    <script src="/js/workspaces/main.js" type="text/javascript"></script>
+    <script src="/js/main.js" type="text/javascript"></script>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">
   </body>
 </html>
 ----
+
+You can save it in `resources/public/workspaces/index.html`
 
 Then create the entry point for the workspaces:
 
@@ -78,10 +80,10 @@ Then create the entry point for the workspaces:
 ----
 ;; shadow-cljs configuration
 {:builds {:workspaces {:target           :browser
-                       :output-dir       "resources/public/js/workspaces"
-                       :asset-path       "/js/workspaces"
+                       :output-dir       "resources/public/workspaces/js"
+                       :asset-path       "/js"
                        :devtools         {;:preloads   [fulcro.inspect.preload ] ; include for Fulcro Inspect support
-                                          :http-root          "resources/public"
+                                          :http-root          "resources/public/workspaces"
                                           :http-port          3689
                                           :http-resource-root "."
                                           :preloads []}
@@ -93,6 +95,8 @@ Now run with:
 ....
 npx shadow-cljs watch workspaces
 ....
+
+Then, it should be available at [localhost:3689](http://localhost:3689).
 
 === With Figwheel
 
@@ -123,9 +127,9 @@ So you can call the hook forom there, as:
                 :figwheel     {:on-jsload "myapp.workspaces.main/on-js-reload"}
 
                 :compiler     {:main                 myapp.workspaces.main
-                               :asset-path           "js/workspaces/out"
-                               :output-to            "resources/public/js/workspaces/main.js"
-                               :output-dir           "resources/public/js/workspaces/out"
+                               :asset-path           "workspaces/js/out"
+                               :output-to            "resources/public/workspaces/js/main.js"
+                               :output-dir           "resources/public/workspaces/js/out"
                                :source-map-timestamp true
                                :preloads             [devtools.preload]}}]}
 ----
@@ -135,6 +139,8 @@ Now run with:
 ....
 lein figwheel
 ....
+
+Then, it should be available at [localhost:3689](http://localhost:3689).
 
 == Creating cards
 


### PR DESCRIPTION
Also, it changes the URL

Before, one should access `localhost:3689/workspaces.html`

Now, it should be available at `localhost:3689`

In my setup, for example, the normal app is at `localhost:8020` and workspaces at `localhost:3689`, without any collision