### PR TITLE
Removed the broken link for fulcro-incubator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,9 +31,6 @@ image:https://cljdoc.xyz/badge/nubank/workspaces[link=https://cljdoc.xyz/d/nuban
 Workspaces is a component development environment for ClojureScript,
 inspired by https://github.com/bhauman/devcards[devcards].
 
-If you just want to see an example of Workspaces in action, check
-https://fulcrologic.github.io/fulcro-incubator/[Fulcro Incubator public
-workspace].
 
 image:workspaces-main.gif[Workspaces Main]
 


### PR DESCRIPTION
I've removed the broken link for  https://fulcrologic.github.io/fulcro-incubator as it now lives in the https://github.com/fulcro-legacy org which doesn't have a github org website. 

Hopefully we can add it back soon enough with `fulcro3`.