### PR TITLE
Allow timeout of testcards to be configured

### DIFF
--- a/examples/workspaces-shadow-example/deps.edn
+++ b/examples/workspaces-shadow-example/deps.edn
@@ -5,6 +5,6 @@
  {binaryage/devtools         {:mvn/version "0.9.10"}
   fulcrologic/fulcro         {:mvn/version "2.8.12" :exclusions [org.clojure/clojurescript org.clojure/core.async]}
   fulcrologic/fulcro-inspect {:mvn/version "2.2.1"}
-  nubank/workspaces          {:mvn/version "1.0.9"}
+  nubank/workspaces          {:mvn/version "1.0.14-SNAPSHOT"}
   re-frame                   {:mvn/version "0.10.5"}
   thheller/shadow-cljs       {:mvn/version "2.8.42"}}}

--- a/examples/workspaces-shadow-example/src/myapp/workspaces/cards.cljs
+++ b/examples/workspaces-shadow-example/src/myapp/workspaces/cards.cljs
@@ -2,7 +2,8 @@
   (:require [nubank.workspaces.core :as ws]
             [nubank.workspaces.model :as wsm]
             [nubank.workspaces.card-types.react :as ct.react]
-            [cljs.test :refer [is]]
+            [nubank.workspaces.card-types.test :as ct.test]
+            [cljs.test :refer [is async]]
             [fulcro.client.dom :as dom]))
 
 ; simple function to create react elemnents
@@ -23,6 +24,12 @@
 
 (ws/deftest sample-test
   (is (= 1 1)))
+
+(ws/deftest longrunning-test
+  {::ct.test/timeout 2000}
+  (async done (js/setTimeout (fn [] (is (= 1 1))
+                                    (done))
+                             1000)))
 
 (ws/defcard styles-card
   {::wsm/node-props {:style {:background "red" :color "white"}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/workspaces "1.0.13"
+(defproject nubank/workspaces "1.0.14-SNAPSHOT"
   :description "Work environments for development of web apps."
   :url "https://github.com/nubank/workspaces"
   :license {:name "Apache License 2.0"


### PR DESCRIPTION
For an example, please see [`longrunning-test` at `examples/workspaces-shadow-example/src/myapp/workspaces/cards.cljs`](https://github.com/nubank/workspaces/compare/master...johannesloetzsch:master#diff-49abf5ce132ee7af2f885deca81ba638R28)