### PR TITLE
Make some small design adjustments and add dark theme

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
   {:extra-deps
    {org.clojure/clojure       {:mvn/version "1.9.0"}
     org.clojure/clojurescript {:mvn/version "1.10.439"}
-    thheller/shadow-cljs      {:mvn/version "2.7.13"}}}
+    thheller/shadow-cljs      {:mvn/version "2.11.18"}}}
 
   :dev
   {:extra-paths

--- a/src/nubank/workspaces/card_types/test.cljs
+++ b/src/nubank/workspaces/card_types/test.cljs
@@ -521,16 +521,16 @@
 (defn runnable-status-color [{::keys [disabled? done? running? enqueued? success?]}]
   (cond
     disabled?
-    uc/color-light-grey
+    (uc/color ::uc/test-header-disabled-bg)
 
     done?
-    (if success? uc/color-mint-green uc/color-red-dark)
+    (if success? (uc/color ::uc/test-header-success-bg) (uc/color ::uc/test-header-error-bg))
 
     running?
-    uc/color-yellow
+    (uc/color ::uc/test-header-running-bg)
 
     enqueued?
-    uc/color-yellow))
+    (uc/color ::uc/test-header-waiting-bg)))
 
 (fp/defsc NSTestGroup
   [this {::keys [test-vars] :as props}]

--- a/src/nubank/workspaces/card_types/test.cljs
+++ b/src/nubank/workspaces/card_types/test.cljs
@@ -412,22 +412,22 @@
       (cond
         enqueued?
         (do
-          (header-color uc/color-yellow)
+          (header-color (uc/color ::uc/test-header-waiting-bg))
           "Waiting to run...")
 
         running?
         (do
-          (header-color uc/color-yellow)
+          (header-color ::uc/test-header-running-bg)
           "Running...")
 
         (test-success? test-results)
         (do
-          (header-color uc/color-mint-green)
+          (header-color (uc/color ::uc/test-header-success-bg))
           (mapv test-result summary))
 
         :else
         (do
-          (header-color uc/color-red-dark)
+          (header-color (uc/color ::uc/test-header-error-bg))
           (mapv test-result summary))))))
 
 (defn test-card-init [card test]

--- a/src/nubank/workspaces/card_types/test.cljs
+++ b/src/nubank/workspaces/card_types/test.cljs
@@ -613,13 +613,13 @@
     (dom/div :.test-ns
       (cond
         done?
-        (header-color (if success? uc/color-mint-green uc/color-red-dark))
+        (header-color (if success? (uc/color ::uc/test-header-success-bg) (uc/color ::uc/test-header-error-bg)))
 
         running?
-        (header-color uc/color-yellow)
+        (header-color (uc/color ::uc/test-header-running-bg))
 
         enqueued?
-        (header-color uc/color-yellow))
+        (header-color (uc/color ::uc/test-header-waiting-bg)))
 
       (mapv all-test-ns-test-group test-namespaces))))
 

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -210,7 +210,8 @@
                                  :padding     "10px"}]
 
                        [:.card
-                        {:display         "flex"
+                        {:background      (uc/color ::uc/card-default-bg)
+                         :display         "flex"
                          :flex            "1"
                          :align-items     "center"
                          :justify-content "center"

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -253,8 +253,9 @@
    :ident             [::wsm/card-id ::wsm/card-id]
    :query             [::wsm/card-id ::wsm/card-header-style ::show-source?
                        {[::workspace-root "singleton"] [::settings]}]
-   :css               [[:.container {:background     (uc/color ::uc/card-bg)
-                                     :box-shadow     "0 4px 9px 0 rgba(0,0,0,0.02)"
+   :css               [[:.container {:color-scheme   (uc/color ::uc/card-default-color-scheme)
+                                     :background     (uc/color ::uc/card-bg)
+                                     :box-shadow     "0 4px 9px 0 rgba(0,0,0,0.08)"
                                      :border-radius  uc/card-border-radius
                                      :display        "flex"
                                      :flex-direction "column"
@@ -945,10 +946,11 @@
                     {::workspaces (fp/get-query WorkspaceIndexListing)}
                     {::ws-tabs (fp/get-query WorkspaceTabs)}
                     {::spotlight (fp/get-query spotlight/Spotlight)}]
-   :css            [[:body {:margin     0
-                            :overflow   "hidden"
-                            :background (uc/color ::uc/bg)
-                            :color      (uc/color ::uc/primary-text-color)}]
+   :css            [[:body {:margin       0
+                            :overflow     "hidden"
+                            :color-scheme (uc/color ::uc/color-scheme)
+                            :background   (uc/color ::uc/bg)
+                            :color        (uc/color ::uc/primary-text-color)}]
                     [:.container {:box-sizing "border-box"
                                   :display    "flex"
                                   :width      "100vw"

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -188,7 +188,8 @@
   {:initial-state     (fn [data] data)
    :ident             [::wsm/card-id ::wsm/card-id]
    :query             [::wsm/card-id]
-   :css               [[:.container {:background     (uc/color ::uc/card-bg)
+   :css               [[:.container {:color-scheme   (uc/color ::uc/card-default-color-scheme)
+                                     :background     (uc/color ::uc/card-bg)
                                      :box-shadow     "0 4px 9px 0 rgba(0,0,0,0.02)"
                                      :border-radius  uc/card-border-radius
                                      :display        "flex"
@@ -198,11 +199,12 @@
 
                        [:.toolbar
                         uc/font-os12sb
-                        {:align-items     "center"
-                         :background      (uc/color ::uc/card-toolbar-bg)
-                         :display         "flex"
+                        {:display         "flex"
+                         :align-items     "center"
                          :justify-content "flex-end"
-                         :padding         "6px"}
+                         :padding         "6px"
+                         :background      (uc/color ::uc/card-toolbar-bg)
+                         :color           (uc/color ::uc/card-toolbar-default-text)}
                         [:button {:margin-left "5px"}]]
 
                        [:.error {:color       (uc/color ::uc/error-text-color)
@@ -210,13 +212,14 @@
                                  :padding     "10px"}]
 
                        [:.card
-                        {:background      (uc/color ::uc/card-default-bg)
-                         :display         "flex"
+                        {:display         "flex"
                          :flex            "1"
                          :align-items     "center"
                          :justify-content "center"
                          :overflow        "auto"
-                         :padding         "10px"}]]
+                         :padding         "10px"
+                         :background      (uc/color ::uc/card-default-bg)
+                         :color           (uc/color ::uc/card-default-text)}]]
 
    :componentDidMount (fn []
                         (let [{::wsm/keys [card-id]} (fp/props this)
@@ -324,12 +327,12 @@
                          :grid-gap      "6px"}]
 
                        [:.toolbar
-                        {:align-items     "center"
-                         :background      (uc/color ::uc/card-toolbar-bg)
-                         :color           (uc/color ::uc/card-toolbar-default-text)
-                         :display         "flex"
+                        {:display         "flex"
+                         :align-items     "center"
                          :justify-content "flex-end"
-                         :padding         "6px"}
+                         :background      (uc/color ::uc/card-toolbar-bg)
+                         :padding         "6px"
+                         :color           (uc/color ::uc/card-toolbar-default-text)}
                         [:button {:margin-left "5px"}]]
 
                        [:$react-draggable-dragging
@@ -348,6 +351,7 @@
                          :justify-content "center"
                          :overflow        "auto"
                          :padding         "10px"
+                         :background      (uc/color ::uc/card-default-bg)
                          :color           (uc/color ::uc/card-default-text)}]
 
                        [:.source

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -324,6 +324,7 @@
                        [:.toolbar
                         {:align-items     "center"
                          :background      (uc/color ::uc/card-toolbar-bg)
+                         :color           (uc/color ::uc/card-toolbar-default-text)
                          :display         "flex"
                          :justify-content "flex-end"
                          :padding         "6px"}

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -931,7 +931,7 @@
     (dom/div (dom/strong (get-keybinding ::keybinding-toggle-card-headers)) ": Toggle card headers")
     (dom/div (dom/strong (get-keybinding ::keybinding-new-workspace)) ": Create new local workspace")
     (dom/div (dom/strong (get-keybinding ::keybinding-close-workspace)) ": Close current workspace")
-    (dom/div (dom/strong "alt-shift-?") ": Toggle shorcuts modal")))
+    (dom/div (dom/strong "alt-shift-?") ": Toggle shortcuts modal")))
 
 (def help-dialog (fp/factory HelpDialog))
 

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -719,7 +719,8 @@
                                  :max-width      "100%"}]
                    [:.tabs {:display    "flex"
                             :flex-wrap  "nowrap"
-                            :overflow-x "auto"}]
+                            :overflow-x "auto"
+                            :overflow-y "hidden"}]
                    [:.tab
                     uc/font-os12sb
                     {:background    (uc/color ::uc/tab-bg)

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -606,16 +606,23 @@
                        {::cards (fp/get-query WorkspaceCard)}]
    :css               [[:.container {:display        "flex"
                                      :flex           "1"
-                                     :flex-direction "column"}]
+                                     :flex-direction "column"
+                                     :font-size      "12px"}]
                        [:.grid {:flex       "1"
                                 :overflow-y "auto"
                                 :overflow-x "hidden"}]
                        [:.tools {:background  (uc/color ::uc/workspace-tools-bg)
                                  :color       (uc/color ::uc/workspace-tools-color)
-                                 :padding     "5px 9px"
+                                 :padding     "8px 10px"
                                  :display     "flex"
                                  :align-items "center"}
-                        [:button {:margin-left "5px"}]]
+                        [:select {:height      "24px"
+                                  :font-size   "12px"
+                                  :font-weight "600"}]
+                        [:button {:font-size   "12px"
+                                  :line-height "2"
+                                  :margin-left "10px"
+                                  :padding     "0 8px"}]]
                        [:.breakpoint {:flex "1"}]]
 
    :css-include       [grid/GridLayout]
@@ -730,17 +737,18 @@
                    [:.tab
                     uc/font-os12sb
                     {:background    (uc/color ::uc/tab-bg)
-                     :border        (str "1px solid " (uc/color ::uc/tab-border))
-                     :border-radius "6px 6px 0 0"
+                     :border-top    (str "1px solid " (uc/color ::uc/tab-border))
+                     :border-right  (str "1px solid " (uc/color ::uc/tab-border))
+                     :border-left   (str "1px solid " (uc/color ::uc/tab-border))
+                     :border-radius "4px 4px 0 0"
                      :color         (uc/color ::uc/tab-text)
                      :cursor        "pointer"
                      :display       "flex"
                      :flex          "0 0 auto"
                      :align-items   "center"
                      :margin-right  "1px"
-                     :margin-bottom "-1px"
                      :overflow      "hidden"
-                     :padding       "7px 12px 9px"
+                     :padding       "8px 12px 8px 10px"
                      :z-index       "1"}
                     [:&.active-tab {:background (uc/color ::uc/tab-active-bg)}]]
                    [:.active {:border     (str "1px solid " (uc/color ::uc/tab-border))
@@ -748,7 +756,8 @@
                               :flex       "1"
                               :min-height "0"}]
                    [:.new-tab {:font-size   "23px"
-                               :line-height "1em"}]
+                               :line-height "1em"
+                               :padding     "8px 12px"}]
                    [:.welcome {:background      (uc/color ::uc/welcome-msg-bg)
                                :color           "#fff"
                                :flex            "1"
@@ -768,7 +777,7 @@
                      :box-shadow    "0 0 2px 0 transparent"
                      :cursor        "pointer"
                      :flex          "1"
-                     :max-width     "150px"
+                     :max-width     "152px"
                      :overflow      "hidden"
                      :text-overflow "ellipsis"
                      :white-space   "nowrap"}

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -785,7 +785,6 @@
                                :border     "1px solid #0079bf"
                                :box-shadow "0 0 2px 0 #0284c6"
                                :outline    "0"
-                               :color      "#000 !important"
                                :cursor     "text"}]]
                    [:.workspace-close
                     uc/close-icon-css

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -758,14 +758,13 @@
                    [:.new-tab {:font-size   "23px"
                                :line-height "1em"
                                :padding     "8px 12px"}]
-                   [:.welcome {:background      (uc/color ::uc/welcome-msg-bg)
-                               :color           "#fff"
+                   [:.welcome {:background      (uc/color ::uc/welcome-container-bg)
                                :flex            "1"
                                :display         "flex"
                                :align-items     "center"
                                :justify-content "center"}]
-                   [:.welcome-content {:background  "#fff"
-                                       :color       "#000"
+                   [:.welcome-content {:background  (uc/color ::uc/welcome-msg-bg)
+                                       :color       (uc/color ::uc/welcome-msg-text)
                                        :font-family uc/font-open-sans
                                        :padding     "0 12px"}
                     [:p {:margin "12px 0"}]]

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -977,6 +977,10 @@
                              :flex-shrink   "0"
                              :overflow      "auto"
                              :min-width     "300px"}]
+                    [:.settings-container {:background (uc/color ::uc/settings-bg)
+                                           :color      (uc/color ::uc/settings-text)
+                                           :padding    "12px"
+                                           :width      "300px"}]
                     [:.workspaces {:display    "flex"
                                    :flex       "1"
                                    :max-height "100vh"
@@ -1055,7 +1059,17 @@
 
     (if show-settings-modal?
       (modal/modal {::modal/on-close #(fm/set-value! this ::show-settings-modal? false)}
-        (help-dialog {})))
+        (dom/div :.settings-container
+          (dom/h2 "Theme")
+          (dom/select {:value    (::uc/theme settings)
+                       :onChange (fn [e]
+                                   (let [v     (gobj/getValueByKeys e "target" "value")
+                                         theme (some->> v (keyword "theme"))]
+                                     (fm/set-value! this ::settings (merge settings {::uc/theme theme}))
+                                     (local-storage/set! ::uc/theme theme)))}
+            (dom/option {:value "auto"} "Auto")
+            (dom/option {:value "light"} "Light")
+            (dom/option {:value "dark"} "Dark")))))
 
     (if show-spotlight?
       (modal/modal {::modal/on-close #(fm/set-value! this ::show-spotlight? false)}

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -602,7 +602,7 @@
                                      :flex           "1"
                                      :flex-direction "column"}]
                        [:.grid {:flex       "1"
-                                :overflow-y "scroll"
+                                :overflow-y "auto"
                                 :overflow-x "hidden"}]
                        [:.tools {:background  (uc/color ::uc/workspace-tools-bg)
                                  :color       (uc/color ::uc/workspace-tools-color)
@@ -736,9 +736,8 @@
                      :overflow      "hidden"
                      :padding       "7px 12px 9px"
                      :z-index       "1"}
-                    [:&.active-tab {:background    (uc/color ::uc/tab-active-bg)
-                                    :border-bottom (str "1px solid " uc/color-white)}]]
-                   [:.active {:border     (str "1px solid " uc/color-geyser)
+                    [:&.active-tab {:background (uc/color ::uc/tab-active-bg)}]]
+                   [:.active {:border     (str "1px solid " (uc/color ::uc/tab-border))
                               :display    "flex"
                               :flex       "1"
                               :min-height "0"}]

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -936,7 +936,7 @@
 
 (fp/defsc WorkspacesRoot
   [this {::keys [cards ws-tabs workspaces settings expanded spotlight show-spotlight?
-                 show-help-modal? show-settings-modal?]}]
+                 show-help-modal?]}]
   {:initial-state  (fn [card-definitions]
                      {::cards                (mapv #(fp/get-initial-state CardIndexListing %)
                                                (vals card-definitions))
@@ -951,11 +951,10 @@
                       ::spotlight            (fp/get-initial-state spotlight/Spotlight [])
                       ::show-spotlight?      false
                       ::show-help-modal?     false
-                      ::show-settings-modal? false
                       ::settings             {::show-index? (local-storage/get ::show-index? true)
                                               ::uc/theme    (local-storage/get ::uc/theme uc/default-theme)}})
    :ident          (fn [] [::workspace-root "singleton"])
-   :query          [::settings ::expanded ::show-spotlight? ::show-help-modal? ::show-settings-modal?
+   :query          [::settings ::expanded ::show-spotlight? ::show-help-modal?
                     {::cards (fp/get-query CardIndexListing)}
                     {::workspaces (fp/get-query WorkspaceIndexListing)}
                     {::ws-tabs (fp/get-query WorkspaceTabs)}
@@ -1053,20 +1052,6 @@
     (if show-help-modal?
       (modal/modal {::modal/on-close #(fm/set-value! this ::show-help-modal? false)}
         (help-dialog {})))
-
-    (if show-settings-modal?
-      (modal/modal {::modal/on-close #(fm/set-value! this ::show-settings-modal? false)}
-        (dom/div :.settings-container
-          (dom/h2 "Theme")
-          (dom/select {:value    (::uc/theme settings)
-                       :onChange (fn [e]
-                                   (let [v     (gobj/getValueByKeys e "target" "value")
-                                         theme (some->> v (keyword "theme"))]
-                                     (fm/set-value! this ::settings (merge settings {::uc/theme theme}))
-                                     (local-storage/set! ::uc/theme theme)))}
-            (dom/option {:value "auto"} "Auto")
-            (dom/option {:value "light"} "Light")
-            (dom/option {:value "dark"} "Dark")))))
 
     (if show-spotlight?
       (modal/modal {::modal/on-close #(fm/set-value! this ::show-spotlight? false)}

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -981,15 +981,15 @@
                                    :flex       "1"
                                    :max-height "100vh"
                                    :overflow   "hidden"}]
-                    [:.index-action-button {:background   "transparent"
-                                            :border       "none"
-                                            :cursor       "pointer"
-                                            :font-size    "23px"
-                                            :font-weight  "bold"
-                                            :margin-right "5px"
-                                            :margin-top   "-4px"
-                                            :outline      "none"
-                                            :padding      "0"}
+                    [:.index-action-button {:background  "transparent"
+                                            :border      "none"
+                                            :cursor      "pointer"
+                                            :font-size   "23px"
+                                            :font-weight "bold"
+                                            :width       "20px"
+                                            :margin-top  "-4px"
+                                            :outline     "none"
+                                            :padding     "0"}
                      [:&.spotlight {:color       "transparent"
                                     :text-shadow "0 0 #ffffff"
                                     :font-size   "14px"
@@ -1129,7 +1129,7 @@
               (if (get-in expanded [:test-ns ns])
                 (dom/div :.nest-group
                   (mapv card-index-listing (sort-by ::wsm/card-id cards))))))))
-      (dom/div :.menu-show
+      (dom/div
         (dom/button :.index-action-button {:onClick #(fp/transact! this [`(toggle-index-view {})])}
           "»")))
     (dom/div :.workspaces

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -951,7 +951,8 @@
                       ::spotlight        (fp/get-initial-state spotlight/Spotlight [])
                       ::show-spotlight?  false
                       ::show-help-modal? false
-                      ::settings         {::show-index? (local-storage/get ::show-index? true)}})
+                      ::settings         {::show-index? (local-storage/get ::show-index? true)
+                                          ::uc/theme    (local-storage/get ::uc/theme uc/default-theme)}})
    :ident          (fn [] [::workspace-root "singleton"])
    :query          [::settings ::expanded ::show-spotlight? ::show-help-modal?
                     {::cards (fp/get-query CardIndexListing)}
@@ -988,12 +989,11 @@
                                             :margin-top  "-4px"
                                             :outline     "none"
                                             :padding     "0"}
+                     ["&:not(:first-child)" {:margin    "-2px 10px 0 0"}]
                      [:&.spotlight {:color       "transparent"
                                     :text-shadow "0 0 #ffffff"
-                                    :font-size   "14px"
-                                    :margin      "-2px 10px 0 0"}]
-                     [:&.help {:font-size "17px"
-                               :margin    "-2px 10px 0 0"}]]
+                                    :font-size   "14px"}]
+                     [:&.help {:font-size "17px"}]]
                     [:.header {:background    (uc/color ::uc/menu-header-bg)
                                :border-radius "4px"
                                :color         "#fff"
@@ -1064,6 +1064,8 @@
           (dom/div :.row.header
             (dom/div "Workspaces")
             (dom/div :.flex)
+            (dom/button :.index-action-button {:onClick #(fp/transact! this [`(toggle-index-view {})])}
+              "\u2699")
             (dom/button :.index-action-button.spotlight {:onClick #(open-spotlight this)}
               "\uD83D\uDD0D")
             (dom/button :.index-action-button.help {:onClick #(fm/toggle! this ::show-help-modal?)}

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -188,7 +188,7 @@
   {:initial-state     (fn [data] data)
    :ident             [::wsm/card-id ::wsm/card-id]
    :query             [::wsm/card-id]
-   :css               [[:.container {:background     uc/color-white
+   :css               [[:.container {:background     (uc/color ::uc/card-bg)
                                      :box-shadow     "0 4px 9px 0 rgba(0,0,0,0.02)"
                                      :border-radius  uc/card-border-radius
                                      :display        "flex"
@@ -199,13 +199,13 @@
                        [:.toolbar
                         uc/font-os12sb
                         {:align-items     "center"
-                         :background      uc/color-geyser
+                         :background      (uc/color ::uc/card-toolbar-bg)
                          :display         "flex"
                          :justify-content "flex-end"
                          :padding         "6px"}
                         [:button {:margin-left "5px"}]]
 
-                       [:.error {:color       "#ef0000"
+                       [:.error {:color       (uc/color ::uc/error-text-color)
                                  :font-weight "bold"
                                  :padding     "10px"}]
 
@@ -253,7 +253,7 @@
    :ident             [::wsm/card-id ::wsm/card-id]
    :query             [::wsm/card-id ::wsm/card-header-style ::show-source?
                        {[::workspace-root "singleton"] [::settings]}]
-   :css               [[:.container {:background     uc/color-white
+   :css               [[:.container {:background     (uc/color ::uc/card-bg)
                                      :box-shadow     "0 4px 9px 0 rgba(0,0,0,0.02)"
                                      :border-radius  uc/card-border-radius
                                      :display        "flex"
@@ -264,13 +264,13 @@
                        [:$cljs-workflow-static-workflow
                         [:.header {:cursor "default"}]]
 
-                       [:.error {:color       "#ef0000"
+                       [:.error {:color       (uc/color ::uc/error-text-color)
                                  :font-weight "bold"
                                  :padding     "10px"}]
 
                        [:.header
                         uc/font-os12sb
-                        {:background    uc/color-mystic
+                        {:background    (uc/color ::uc/card-header-bg)
                          :border-radius (str uc/card-border-radius " " uc/card-border-radius " 0 0")
                          :color         uc/color-limed-spruce
                          :cursor        "grab"}
@@ -316,14 +316,14 @@
 
                        [:.more-actions
                         {:display       "grid"
-                         :background    uc/color-mystic
+                         :background    (uc/color ::uc/card-ellipsis-menu-bg)
                          :border-radius "0 0 6px 6px"
                          :padding       "5px 10px 10px"
                          :grid-gap      "6px"}]
 
                        [:.toolbar
                         {:align-items     "center"
-                         :background      uc/color-geyser
+                         :background      (uc/color ::uc/card-toolbar-bg)
                          :display         "flex"
                          :justify-content "flex-end"
                          :padding         "6px"}
@@ -602,19 +602,19 @@
                        [:.grid {:flex       "1"
                                 :overflow-y "scroll"
                                 :overflow-x "hidden"}]
-                       [:.tools {:background  uc/color-white
-                                 :color       uc/color-limed-spruce
+                       [:.tools {:background  (uc/color ::uc/workspace-tools-bg)
+                                 :color       (uc/color ::uc/workspace-tools-color)
                                  :padding     "5px 9px"
                                  :display     "flex"
                                  :align-items "center"}
                         [:button {:margin-left "5px"}]]
                        [:.breakpoint {:flex "1"}]]
 
+   :css-include       [grid/GridLayout]
+
    :componentDidCatch (fn [error info]
                         (swap! components-with-error conj this)
                         (fp/set-state! this {::error-catch? true}))
-
-   :css-include       [grid/GridLayout]
    :componentDidMount (fn [] (js/requestAnimationFrame #(fp/set-state! this {:render? true})))}
 
   (if (fp/get-state this ::error-catch?)
@@ -681,7 +681,7 @@
                    ::wsm/card-id  (fp/get-query WorkspaceSoloCard)})
    :css         [[:$workspaces-workspace-container {:background "#9fa2ab"
                                                     :flex       "1"}]
-                 [:.error {:color       "#ef0000"
+                 [:.error {:color       (uc/color ::uc/error-text-color)
                            :font-weight "bold"
                            :padding     "10px"}]]
 
@@ -720,7 +720,7 @@
                             :overflow-x "auto"}]
                    [:.tab
                     uc/font-os12sb
-                    {:background    uc/color-iron
+                    {:background    (uc/color ::uc/tab-bg)
                      :border        (str "1px solid " uc/color-geyser)
                      :border-radius "6px 6px 0 0"
                      :color         uc/color-limed-spruce
@@ -733,7 +733,7 @@
                      :overflow      "hidden"
                      :padding       "7px 12px 9px"
                      :z-index       "1"}
-                    [:&.active-tab {:background    uc/color-white
+                    [:&.active-tab {:background    (uc/color ::uc/tab-active-bg)
                                     :border-bottom (str "1px solid " uc/color-white)}]]
                    [:.active {:border     (str "1px solid " uc/color-geyser)
                               :display    "flex"
@@ -741,7 +741,7 @@
                               :min-height "0"}]
                    [:.new-tab {:font-size   "23px"
                                :line-height "1em"}]
-                   [:.welcome {:background      uc/color-dark-grey
+                   [:.welcome {:background      (uc/color ::uc/welcome-msg-bg)
                                :color           "#fff"
                                :flex            "1"
                                :display         "flex"
@@ -754,17 +754,16 @@
                     [:p {:margin "12px 0"}]]
                    [:.workspace-title
                     uc/font-os12sb
-                    {:background    "transparent"
+                    {:background    (uc/color ::uc/tab-text-field-bg)
                      :border        "1px solid transparent"
                      :box-shadow    "0 0 2px 0 transparent"
                      :cursor        "pointer"
-                     :direction     "rtl"
                      :flex          "1"
                      :max-width     "150px"
                      :overflow      "hidden"
                      :text-overflow "ellipsis"
                      :white-space   "nowrap"}
-                    [:&:focus {:background "#fff"
+                    [:&:focus {:background (uc/color ::uc/tab-text-field-focus-bg)
                                :border     "1px solid #0079bf"
                                :box-shadow "0 0 2px 0 #0284c6"
                                :outline    "0"
@@ -896,7 +895,7 @@
 (fp/defsc HelpDialog
   [this {::keys []}]
   {:css [[:.container
-          {:background    "rgba(0, 0, 0, 0.8)"
+          {:background    (uc/color ::uc/help-dialog-bg)
            :border-radius "4px"
            :color         "#fff"
            :font-family   uc/font-monospace
@@ -924,10 +923,10 @@
                  show-help-modal?]}]
   {:initial-state  (fn [card-definitions]
                      {::cards            (mapv #(fp/get-initial-state CardIndexListing %)
-                                          (vals card-definitions))
+                                           (vals card-definitions))
                       ::workspaces       (->> (local-storage/get ::local-workspaces [])
                                               (mapv #(fp/get-initial-state Workspace
-                                                      (local-storage/tget [::workspace-id %])))
+                                                       (local-storage/tget [::workspace-id %])))
                                               (into (initialize-static-workspaces)))
 
                       ::expanded         (local-storage/get ::expanded {})
@@ -944,14 +943,16 @@
                     {::ws-tabs (fp/get-query WorkspaceTabs)}
                     {::spotlight (fp/get-query spotlight/Spotlight)}]
    :css            [[:body {:margin     0
-                            :background "#f7f7f7"
-                            :overflow   "hidden"}]
+                            :overflow   "hidden"
+                            :background (uc/color ::uc/bg)
+                            :color      (uc/color ::uc/primary-text-color)}]
                     [:.container {:box-sizing "border-box"
                                   :display    "flex"
                                   :width      "100vw"
                                   :height     "100vh"
                                   :padding    "10px"}]
-                    [:.menu {:padding-right "10px"
+                    [:.menu {:background    (uc/color ::uc/menu-bg)
+                             :padding-right "10px"
                              :font-family   uc/font-open-sans
                              :flex-shrink   "0"
                              :overflow      "auto"
@@ -975,7 +976,7 @@
                                     :margin      "-2px 10px 0 0"}]
                      [:&.help {:font-size "17px"
                                :margin    "-2px 10px 0 0"}]]
-                    [:.header {:background    "#404040"
+                    [:.header {:background    (uc/color ::uc/menu-header-bg)
                                :border-radius "4px"
                                :color         "#fff"
                                :font-weight   "bold"

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -588,13 +588,13 @@
   {:initial-state     (fn [{::keys [layouts workspace-title workspace-id] :as ws}]
                         (let [layouts (or layouts {})]
                           (merge ws
-                                 {::workspace-id    (or workspace-id (random-uuid))
-                                  ::workspace-title (or workspace-title "new workspace")
-                                  ::cards           (or (some->> layouts first val
-                                                          (mapv #(vector ::wsm/card-id (get % "i"))))
-                                                        [])
-                                  ::layouts         layouts
-                                  ::breakpoint      ""})))
+                            {::workspace-id    (or workspace-id (random-uuid))
+                             ::workspace-title (or workspace-title "new workspace")
+                             ::cards           (or (some->> layouts first val
+                                                            (mapv #(vector ::wsm/card-id (get % "i"))))
+                                                   [])
+                             ::layouts         layouts
+                             ::breakpoint      ""})))
    :ident             [::workspace-id ::workspace-id]
    :query             [::workspace-id ::layouts ::breakpoint
                        ::workspace-title ::wsm/workspace-static?
@@ -946,17 +946,18 @@
                     {::workspaces (fp/get-query WorkspaceIndexListing)}
                     {::ws-tabs (fp/get-query WorkspaceTabs)}
                     {::spotlight (fp/get-query spotlight/Spotlight)}]
-   :css            [[:body {:margin       0
-                            :overflow     "hidden"
-                            :color-scheme (uc/color ::uc/color-scheme)
-                            :background   (uc/color ::uc/bg)
-                            :color        (uc/color ::uc/primary-text-color)}]
-                    [:.container {:box-sizing "border-box"
-                                  :display    "flex"
-                                  :width      "100vw"
-                                  :height     "100vh"
-                                  :padding    "10px"}]
+   :css            [[:body {:margin     0
+                            :overflow   "hidden"
+                            :background (uc/color ::uc/bg)}]
+                    [:.container {:color-scheme (uc/color ::uc/color-scheme)
+                                  :color        (uc/color ::uc/primary-text-color)
+                                  :box-sizing   "border-box"
+                                  :display      "flex"
+                                  :width        "100vw"
+                                  :height       "100vh"
+                                  :padding      "10px"}]
                     [:.menu {:background    (uc/color ::uc/menu-bg)
+                             :color         (uc/color ::uc/menu-text)
                              :padding-right "10px"
                              :font-family   uc/font-open-sans
                              :flex-shrink   "0"

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -936,25 +936,26 @@
 
 (fp/defsc WorkspacesRoot
   [this {::keys [cards ws-tabs workspaces settings expanded spotlight show-spotlight?
-                 show-help-modal?]}]
+                 show-help-modal? show-settings-modal?]}]
   {:initial-state  (fn [card-definitions]
-                     {::cards            (mapv #(fp/get-initial-state CardIndexListing %)
-                                           (vals card-definitions))
-                      ::workspaces       (->> (local-storage/get ::local-workspaces [])
-                                              (mapv #(fp/get-initial-state Workspace
-                                                       (local-storage/tget [::workspace-id %])))
-                                              (into (initialize-static-workspaces)))
+                     {::cards                (mapv #(fp/get-initial-state CardIndexListing %)
+                                               (vals card-definitions))
+                      ::workspaces           (->> (local-storage/get ::local-workspaces [])
+                                                  (mapv #(fp/get-initial-state Workspace
+                                                           (local-storage/tget [::workspace-id %])))
+                                                  (into (initialize-static-workspaces)))
 
-                      ::expanded         (local-storage/get ::expanded {})
-                      ::ws-tabs          (fp/get-initial-state WorkspaceTabs {})
+                      ::expanded             (local-storage/get ::expanded {})
+                      ::ws-tabs              (fp/get-initial-state WorkspaceTabs {})
 
-                      ::spotlight        (fp/get-initial-state spotlight/Spotlight [])
-                      ::show-spotlight?  false
-                      ::show-help-modal? false
-                      ::settings         {::show-index? (local-storage/get ::show-index? true)
-                                          ::uc/theme    (local-storage/get ::uc/theme uc/default-theme)}})
+                      ::spotlight            (fp/get-initial-state spotlight/Spotlight [])
+                      ::show-spotlight?      false
+                      ::show-help-modal?     false
+                      ::show-settings-modal? false
+                      ::settings             {::show-index? (local-storage/get ::show-index? true)
+                                              ::uc/theme    (local-storage/get ::uc/theme uc/default-theme)}})
    :ident          (fn [] [::workspace-root "singleton"])
-   :query          [::settings ::expanded ::show-spotlight? ::show-help-modal?
+   :query          [::settings ::expanded ::show-spotlight? ::show-help-modal? ::show-settings-modal?
                     {::cards (fp/get-query CardIndexListing)}
                     {::workspaces (fp/get-query WorkspaceIndexListing)}
                     {::ws-tabs (fp/get-query WorkspaceTabs)}
@@ -989,7 +990,7 @@
                                             :margin-top  "-4px"
                                             :outline     "none"
                                             :padding     "0"}
-                     ["&:not(:first-child)" {:margin    "-2px 10px 0 0"}]
+                     ["&:not(:first-child)" {:margin "-2px 10px 0 0"}]
                      [:&.spotlight {:color       "transparent"
                                     :text-shadow "0 0 #ffffff"
                                     :font-size   "14px"}]
@@ -1052,6 +1053,10 @@
       (modal/modal {::modal/on-close #(fm/set-value! this ::show-help-modal? false)}
         (help-dialog {})))
 
+    (if show-settings-modal?
+      (modal/modal {::modal/on-close #(fm/set-value! this ::show-settings-modal? false)}
+        (help-dialog {})))
+
     (if show-spotlight?
       (modal/modal {::modal/on-close #(fm/set-value! this ::show-spotlight? false)}
         (spotlight/spotlight
@@ -1064,7 +1069,7 @@
           (dom/div :.row.header
             (dom/div "Workspaces")
             (dom/div :.flex)
-            (dom/button :.index-action-button {:onClick #(fp/transact! this [`(toggle-index-view {})])}
+            (dom/button :.index-action-button {:onClick #(fm/set-value! this ::show-settings-modal? true)}
               "\u2699")
             (dom/button :.index-action-button.spotlight {:onClick #(open-spotlight this)}
               "\uD83D\uDD0D")

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -272,7 +272,7 @@
                         uc/font-os12sb
                         {:background    (uc/color ::uc/card-header-bg)
                          :border-radius (str uc/card-border-radius " " uc/card-border-radius " 0 0")
-                         :color         uc/color-limed-spruce
+                         :color         (uc/color ::uc/card-header-text)
                          :cursor        "grab"}
                         {:cursor "-webkit-grab"}
                         {:cursor "-moz-grab"}]
@@ -344,7 +344,8 @@
                          :align-items     "center"
                          :justify-content "center"
                          :overflow        "auto"
-                         :padding         "10px"}]
+                         :padding         "10px"
+                         :color           (uc/color ::uc/card-default-text)}]
 
                        [:.source
                         {:background    "#fff"
@@ -675,15 +676,15 @@
 
 (fp/defsc WorkspaceContainer
   [this props {::keys [open-solo-card]}]
-  {:ident       (fn [] (workspace-ident props))
-   :query       (fn []
-                  {::workspace-id (fp/get-query Workspace)
-                   ::wsm/card-id  (fp/get-query WorkspaceSoloCard)})
-   :css         [[:$workspaces-workspace-container {:background "#9fa2ab"
-                                                    :flex       "1"}]
-                 [:.error {:color       (uc/color ::uc/error-text-color)
-                           :font-weight "bold"
-                           :padding     "10px"}]]
+  {:ident             (fn [] (workspace-ident props))
+   :query             (fn []
+                        {::workspace-id (fp/get-query Workspace)
+                         ::wsm/card-id  (fp/get-query WorkspaceSoloCard)})
+   :css               [[:$workspaces-workspace-container {:background (uc/color ::uc/workspace-bg)
+                                                          :flex       "1"}]
+                       [:.error {:color       (uc/color ::uc/error-text-color)
+                                 :font-weight "bold"
+                                 :padding     "10px"}]]
 
    :componentDidCatch (fn [error info]
                         (swap! components-with-error conj this)
@@ -721,9 +722,9 @@
                    [:.tab
                     uc/font-os12sb
                     {:background    (uc/color ::uc/tab-bg)
-                     :border        (str "1px solid " uc/color-geyser)
+                     :border        (str "1px solid " (uc/color ::uc/tab-border))
                      :border-radius "6px 6px 0 0"
-                     :color         uc/color-limed-spruce
+                     :color         (uc/color ::uc/tab-text)
                      :cursor        "pointer"
                      :display       "flex"
                      :flex          "0 0 auto"
@@ -755,6 +756,7 @@
                    [:.workspace-title
                     uc/font-os12sb
                     {:background    (uc/color ::uc/tab-text-field-bg)
+                     :color         (uc/color ::uc/tab-text)
                      :border        "1px solid transparent"
                      :box-shadow    "0 0 2px 0 transparent"
                      :cursor        "pointer"

--- a/src/nubank/workspaces/ui.cljs
+++ b/src/nubank/workspaces/ui.cljs
@@ -976,11 +976,8 @@
                              :font-family   uc/font-open-sans
                              :flex-shrink   "0"
                              :overflow      "auto"
-                             :min-width     "300px"}]
-                    [:.settings-container {:background (uc/color ::uc/settings-bg)
-                                           :color      (uc/color ::uc/settings-text)
-                                           :padding    "12px"
-                                           :width      "300px"}]
+                             :min-width     "300px"}
+                     [:select {:margin-right "10px"}]]
                     [:.workspaces {:display    "flex"
                                    :flex       "1"
                                    :max-height "100vh"
@@ -1083,8 +1080,16 @@
           (dom/div :.row.header
             (dom/div "Workspaces")
             (dom/div :.flex)
-            (dom/button :.index-action-button {:onClick #(fm/set-value! this ::show-settings-modal? true)}
-              "\u2699")
+            (dom/select {:value    (::uc/theme settings)
+                         :onChange (fn [e]
+                                     (let [v     (gobj/getValueByKeys e "target" "value")
+                                           theme (some->> v (keyword "theme"))]
+                                       (local-storage/set! ::uc/theme theme)
+                                       (when (js/confirm "Reload page to apply new theme?")
+                                         (js/location.reload))))}
+              (dom/option {:value "auto"} "Auto")
+              (dom/option {:value "light"} "Light")
+              (dom/option {:value "dark"} "Dark"))
             (dom/button :.index-action-button.spotlight {:onClick #(open-spotlight this)}
               "\uD83D\uDD0D")
             (dom/button :.index-action-button.help {:onClick #(fm/toggle! this ::show-help-modal?)}

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -1,7 +1,9 @@
 (ns nubank.workspaces.ui.core
-  (:require [nubank.workspaces.model :as wsm]
-            [fulcro.client.localized-dom :as dom]
-            [fulcro.client.primitives :as fp]))
+  (:require [fulcro.client.localized-dom :as dom]
+            [fulcro.client.primitives :as fp]
+            [goog.object :as gobj]
+            [nubank.workspaces.lib.local-storage :as local-storage]
+            [nubank.workspaces.model :as wsm]))
 
 (def color-white "#fff")
 (def color-light-grey "#b1b1b1")
@@ -130,8 +132,19 @@
 
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
+(def theme-name->colors-map
+  {:theme/light classical-colors
+   :theme/dark  dark-colors})
+
+(def user-defined-theme
+  (local-storage/get ::theme :theme/auto))
+
 (defn color [color-name]
-  (get classical-colors color-name))
+  (let [theme (if (= user-defined-theme :theme/auto)
+                (if (gobj/get (js/matchMedia "(prefers-color-scheme: dark)") "matches") :theme/dark :theme/light)
+                user-defined-theme)
+        colors-map (get theme-name->colors-map theme)]
+    (get colors-map color-name)))
 
 (def card-border-radius "4px")
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -131,7 +131,7 @@
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
 (defn color [color-name]
-  (get dark-colors color-name))
+  (get classical-colors color-name))
 
 (def card-border-radius "4px")
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -54,6 +54,7 @@
 
    ::card-default-color-scheme       "light"
    ::card-bg                         color-white
+   ::card-default-bg                 color-white
    ::card-default-text               "#000"
    ::card-toolbar-bg                 color-geyser
    ::card-toolbar-default-text       color-limed-spruce
@@ -106,7 +107,8 @@
    ::workspace-tools-color           "#fafafa"
 
    ::card-default-color-scheme       "light"
-   ::card-bg                         color-white
+   ::card-bg                         "#202124"
+   ::card-default-bg                 color-white
    ::card-default-text               "#000"
    ::card-toolbar-bg                 color-geyser
    ::card-toolbar-default-text       "#000"

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -39,6 +39,7 @@
    ::menu-header-bg                  color-dark-grey
    ::menu-header-color               color-white
    ::menu-arrow-bg                   color-dark-grey
+   ::menu-text                       "#000"
 
    ::tab-active-bg                   color-white
    ::tab-bg                          color-iron
@@ -83,14 +84,15 @@
 
    ::button-bg                       "#546E7A"
    ::button-active-bg                "#455A64"
-   ::button-color                    color-white
+   ::button-color                    "#fafafa"
    ::button-disabled-bg              "#8c95a0"
    ::button-disabled-color           "#ccc"
 
    ::menu-bg                         "#202124"
    ::menu-header-bg                  "#3f4043"
-   ::menu-header-color               color-white
+   ::menu-header-color               "#fafafa"
    ::menu-arrow-bg                   "#3f4043"
+   ::menu-text                       "#fafafa"
 
    ::tab-active-bg                   "#3f4043"
    ::tab-bg                          "#202124"

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -78,7 +78,12 @@
    ::welcome-msg-text                "#000"
    ::welcome-container-bg            color-dark-grey
 
-   ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
+   ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"
+
+   ::test-header-waiting-bg          color-yellow
+   ::test-header-running-bg          color-yellow
+   ::test-header-success-bg          color-mint-green
+   ::test-header-error-bg            color-red-dark})
 
 (def dark-colors
   {::color-scheme                    "dark"
@@ -134,7 +139,12 @@
    ::welcome-msg-text                "#fafafa"
    ::welcome-container-bg            "#202124"
 
-   ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
+   ::help-dialog-bg                  "#3f4043"
+
+   ::test-header-waiting-bg          "#3f4043"
+   ::test-header-running-bg          "#3f4043"
+   ::test-header-success-bg          "#388E3C"
+   ::test-header-error-bg            "#BF360C"})
 
 (def default-theme :theme/light)
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -56,6 +56,7 @@
    ::card-default-text         "#000"
    ::card-toolbar-bg           color-geyser
    ::card-toolbar-default-text color-limed-spruce
+   ::card-toolbar-more-actions "#000"
    ::card-header-bg            color-mystic
    ::card-header-text          color-limed-spruce
    ::card-ellipsis-menu-bg     color-mystic
@@ -98,6 +99,7 @@
    ::card-default-text         "#000"
    ::card-toolbar-bg           color-geyser
    ::card-toolbar-default-text "#000"
+   ::card-toolbar-more-actions "#fafafa"
    ::card-header-bg            "#3f4043"
    ::card-header-text          "#fafafa"
    ::card-ellipsis-menu-bg     "#3f4043"
@@ -141,7 +143,8 @@
 
 (defn more-icon [props]
   (dom/svg (merge {:width 20 :height 19 :viewBox "0 0 40 40"} props)
-    (dom/g {:fill "#000"} (dom/path {:d "m20 26.6c1.8 0 3.4 1.6 3.4 3.4s-1.6 3.4-3.4 3.4-3.4-1.6-3.4-3.4 1.6-3.4 3.4-3.4z m0-10c1.8 0 3.4 1.6 3.4 3.4s-1.6 3.4-3.4 3.4-3.4-1.6-3.4-3.4 1.6-3.4 3.4-3.4z m0-3.2c-1.8 0-3.4-1.6-3.4-3.4s1.6-3.4 3.4-3.4 3.4 1.6 3.4 3.4-1.6 3.4-3.4 3.4z"}))))
+    (dom/g {:fill (color ::card-toolbar-more-actions)}
+      (dom/path {:d "m20 26.6c1.8 0 3.4 1.6 3.4 3.4s-1.6 3.4-3.4 3.4-3.4-1.6-3.4-3.4 1.6-3.4 3.4-3.4z m0-10c1.8 0 3.4 1.6 3.4 3.4s-1.6 3.4-3.4 3.4-3.4-1.6-3.4-3.4 1.6-3.4 3.4-3.4z m0-3.2c-1.8 0-3.4-1.6-3.4-3.4s1.6-3.4 3.4-3.4 3.4 1.6 3.4 3.4-1.6 3.4-3.4 3.4z"}))))
 
 (fp/defsc Button
   [this props]

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -78,9 +78,6 @@
    ::welcome-msg-text                "#000"
    ::welcome-container-bg            color-dark-grey
 
-   ::settings-bg                     "#3f4043"
-   ::settings-text                   "#fafafa"
-
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
 (def dark-colors
@@ -136,9 +133,6 @@
    ::welcome-msg-bg                  "#3f4043"
    ::welcome-msg-text                "#fafafa"
    ::welcome-container-bg            "#202124"
-
-   ::settings-bg                     "#3f4043"
-   ::settings-text                   "#fafafa"
 
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -78,6 +78,9 @@
    ::welcome-msg-text                "#000"
    ::welcome-container-bg            color-dark-grey
 
+   ::settings-bg                     "#3f4043"
+   ::settings-text                   "#fafafa"
+
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
 (def dark-colors
@@ -133,6 +136,9 @@
    ::welcome-msg-bg                  "#3f4043"
    ::welcome-msg-text                "#fafafa"
    ::welcome-container-bg            "#202124"
+
+   ::settings-bg                     "#3f4043"
+   ::settings-text                   "#fafafa"
 
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -6,18 +6,57 @@
 (def color-white "#fff")
 (def color-light-grey "#b1b1b1")
 (def color-dark-grey "#404040")
+
+(def color-red-dark "#ca2c29")
+(def color-red-light "#f37976")
+
+(def color-green-dark "#187d11")
+(def color-mint-green "#8efd86")
+(def color-green-light "#61d658")
+
+(def color-yellow "#dea54e")
+
 (def color-mystic "#d9e2e9")
 (def color-limed-spruce "#323c47")
 (def color-geyser "#cdd7e0")
 (def color-fiord "#4b5b6d")
 (def color-iron "#e7e8e9")
 
-(def color-red-dark "#ca2c29")
-(def color-red-light "#f37976")
-(def color-green-dark "#187d11")
-(def color-mint-green "#8efd86")
-(def color-green-light "#61d658")
-(def color-yellow "#dea54e")
+(def classical-colors
+  {::bg                      color-white
+   ::primary-text-color      "#000"
+   ::error-text-color        "#ef0000"
+
+   ::button-bg               color-fiord
+   ::button-color            color-white
+   ::button-disabled-bg      "#8c95a0"
+   ::button-disabled-color   "#ccc"
+
+   ::menu-bg                 color-white
+   ::menu-header-bg          color-dark-grey
+   ::menu-header-color       color-white
+   ::menu-arrow-bg           color-dark-grey
+
+   ::tab-active-bg           color-white
+   ::tab-bg                  color-iron
+   ::tab-text-field-bg       "transparent"
+   ::tab-text-field-focus-bg color-white
+
+   ::workspace-bg            "#9fa2ab"
+   ::workspace-tools-bg      color-white
+   ::workspace-tools-color   color-limed-spruce
+
+   ::card-bg                 color-white
+   ::card-header-bg          color-mystic
+   ::card-ellipsis-menu-bg   color-mystic
+   ::card-toolbar-bg         color-geyser
+
+   ::welcome-msg-bg          color-dark-grey
+
+   ::help-dialog-bg          "rgba(0, 0, 0, 0.8)"})
+
+(defn color [color-name]
+  (get classical-colors color-name))
 
 (def card-border-radius "6px")
 
@@ -57,10 +96,10 @@
   [this props]
   {:css [[:.button
           font-os12sb
-          {:background-color color-fiord
+          {:background-color (color ::button-bg)
            :border           "none"
            :border-radius    "3px"
-           :color            color-white
+           :color            (color ::button-color)
            :cursor           "pointer"
            :display          "inline-block"
            :padding          "2px 8px"
@@ -72,8 +111,8 @@
            :user-select      "none"
            :outline          "none"}
           [:&:disabled
-           {:background "#8c95a0"
-            :color      "#ccc"
+           {:background (color ::button-disabled-bg)
+            :color      (color ::button-disabled-color)
             :cursor     "not-allowed"}]]]}
   (apply dom/button :.button props (fp/children this)))
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -143,7 +143,7 @@
    :theme/dark  dark-colors})
 
 (def user-defined-theme
-  (local-storage/get ::theme :theme/light))
+  (local-storage/get ::theme default-theme))
 
 (defn color [color-name]
   (let [theme      (if (= user-defined-theme :theme/auto)

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -39,6 +39,8 @@
 
    ::tab-active-bg           color-white
    ::tab-bg                  color-iron
+   ::tab-text                color-limed-spruce
+   ::tab-border              color-geyser
    ::tab-text-field-bg       "transparent"
    ::tab-text-field-focus-bg color-white
 
@@ -48,15 +50,54 @@
 
    ::card-bg                 color-white
    ::card-header-bg          color-mystic
+   ::card-header-text        color-limed-spruce
    ::card-ellipsis-menu-bg   color-mystic
    ::card-toolbar-bg         color-geyser
+   ::card-default-text       "#000"
+
+   ::welcome-msg-bg          color-dark-grey
+
+   ::help-dialog-bg          "rgba(0, 0, 0, 0.8)"})
+
+(def dark-colors
+  {::bg                      "#212121"
+   ::primary-text-color      "#fafafa"
+   ::error-text-color        "#EF5350"
+
+   ::button-bg               "rgb(138, 5, 190)"
+   ::button-color            color-white
+   ::button-disabled-bg      "#8c95a0"
+   ::button-disabled-color   "#ccc"
+
+   ::menu-bg                 "#212121"
+   ::menu-header-bg          "#616161"
+   ::menu-header-color       color-white
+   ::menu-arrow-bg           "#616161"
+
+   ::tab-active-bg           "#212121"
+   ::tab-bg                  "#212121"
+   ::tab-text                "#fafafa"
+   ::tab-border              "#616161"
+   ::tab-text-field-bg       "transparent"
+   ::tab-text-field-focus-bg "#616161"
+
+   ::workspace-bg            "#212121"
+   ::workspace-tools-bg      "#424242"
+   ::workspace-tools-color   "#fafafa"
+
+   ::card-bg                 color-white
+   ::card-header-bg          "#424242"
+   ::card-header-text        "#fafafa"
+   ::card-ellipsis-menu-bg   "#424242"
+   ::card-toolbar-bg         color-geyser
+   ::card-default-text       "#000"
 
    ::welcome-msg-bg          color-dark-grey
 
    ::help-dialog-bg          "rgba(0, 0, 0, 0.8)"})
 
 (defn color [color-name]
-  (get classical-colors color-name))
+  (get dark-colors color-name))
 
 (def card-border-radius "6px")
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -23,11 +23,14 @@
 (def color-iron "#e7e8e9")
 
 (def classical-colors
-  {::bg                        color-white
+  {::color-scheme              "light"
+
+   ::bg                        color-white
    ::primary-text-color        "#000"
    ::error-text-color          "#ef0000"
 
    ::button-bg                 color-fiord
+   ::button-active-bg          color-fiord
    ::button-color              color-white
    ::button-disabled-bg        "#8c95a0"
    ::button-disabled-color     "#ccc"
@@ -48,51 +51,56 @@
    ::workspace-tools-bg        color-white
    ::workspace-tools-color     color-limed-spruce
 
+   ::card-default-color-scheme "light"
    ::card-bg                   color-white
+   ::card-default-text         "#000"
+   ::card-toolbar-bg           color-geyser
+   ::card-toolbar-default-text color-limed-spruce
    ::card-header-bg            color-mystic
    ::card-header-text          color-limed-spruce
    ::card-ellipsis-menu-bg     color-mystic
-   ::card-toolbar-bg           color-geyser
-   ::card-toolbar-default-text color-limed-spruce
-   ::card-default-text         "#000"
 
    ::welcome-msg-bg            color-dark-grey
 
    ::help-dialog-bg            "rgba(0, 0, 0, 0.8)"})
 
 (def dark-colors
-  {::bg                        "#212121"
+  {::color-scheme              "dark"
+
+   ::bg                        "#202124"
    ::primary-text-color        "#fafafa"
-   ::error-text-color          "#EF5350"
+   ::error-text-color          "#CF6679"
 
    ::button-bg                 "#546E7A"
+   ::button-active-bg          "#455A64"
    ::button-color              color-white
    ::button-disabled-bg        "#8c95a0"
    ::button-disabled-color     "#ccc"
 
-   ::menu-bg                   "#212121"
-   ::menu-header-bg            "#616161"
+   ::menu-bg                   "#202124"
+   ::menu-header-bg            "#3f4043"
    ::menu-header-color         color-white
-   ::menu-arrow-bg             "#616161"
+   ::menu-arrow-bg             "#3f4043"
 
-   ::tab-active-bg             "#424242"
-   ::tab-bg                    "#212121"
+   ::tab-active-bg             "#3f4043"
+   ::tab-bg                    "#202124"
    ::tab-text                  "#fafafa"
-   ::tab-border                "#424242"
+   ::tab-border                "#3f4043"
    ::tab-text-field-bg         "transparent"
    ::tab-text-field-focus-bg   "#616161"
 
-   ::workspace-bg              "#212121"
-   ::workspace-tools-bg        "#424242"
+   ::workspace-bg              "#202124"
+   ::workspace-tools-bg        "#3f4043"
    ::workspace-tools-color     "#fafafa"
 
+   ::card-default-color-scheme "light"
    ::card-bg                   color-white
-   ::card-header-bg            "#424242"
-   ::card-header-text          "#fafafa"
-   ::card-ellipsis-menu-bg     "#424242"
+   ::card-default-text         "#000"
    ::card-toolbar-bg           color-geyser
    ::card-toolbar-default-text "#000"
-   ::card-default-text         "#000"
+   ::card-header-bg            "#3f4043"
+   ::card-header-text          "#fafafa"
+   ::card-ellipsis-menu-bg     "#3f4043"
 
    ::welcome-msg-bg            color-dark-grey
 
@@ -153,6 +161,8 @@
            :vertical-align   "middle"
            :user-select      "none"
            :outline          "none"}
+          [:&:active
+           {:background (color ::button-active-bg)}]
           [:&:disabled
            {:background (color ::button-disabled-bg)
             :color      (color ::button-disabled-color)

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -74,7 +74,9 @@
    ::spotlight-option-selected-bg    "#582074"
    ::spotlight-option-selected-text  color-white
 
-   ::welcome-msg-bg                  color-dark-grey
+   ::welcome-msg-bg                  color-white
+   ::welcome-msg-text                "#000"
+   ::welcome-container-bg            color-dark-grey
 
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
@@ -128,7 +130,9 @@
    ::spotlight-option-selected-bg    "#546E7A"
    ::spotlight-option-selected-text  "#fafafa"
 
-   ::welcome-msg-bg                  color-dark-grey
+   ::welcome-msg-bg                  "#3f4043"
+   ::welcome-msg-text                "#fafafa"
+   ::welcome-container-bg            "#202124"
 
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
@@ -137,7 +141,7 @@
    :theme/dark  dark-colors})
 
 (def user-defined-theme
-  (local-storage/get ::theme :theme/auto))
+  (local-storage/get ::theme :theme/light))
 
 (defn color [color-name]
   (let [theme (if (= user-defined-theme :theme/auto)

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -131,9 +131,9 @@
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
 (defn color [color-name]
-  (get classical-colors color-name))
+  (get dark-colors color-name))
 
-(def card-border-radius "6px")
+(def card-border-radius "4px")
 
 (def font-helvetica "Helvetica Neue,Arial,Helvetica,sans-serif")
 (def font-open-sans "'Open Sans', sans-serif")
@@ -174,7 +174,7 @@
           font-os12sb
           {:background-color (color ::button-bg)
            :border           "none"
-           :border-radius    "3px"
+           :border-radius    "2px"
            :color            (color ::button-color)
            :cursor           "pointer"
            :display          "inline-block"

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -23,78 +23,80 @@
 (def color-iron "#e7e8e9")
 
 (def classical-colors
-  {::bg                      color-white
-   ::primary-text-color      "#000"
-   ::error-text-color        "#ef0000"
+  {::bg                        color-white
+   ::primary-text-color        "#000"
+   ::error-text-color          "#ef0000"
 
-   ::button-bg               color-fiord
-   ::button-color            color-white
-   ::button-disabled-bg      "#8c95a0"
-   ::button-disabled-color   "#ccc"
+   ::button-bg                 color-fiord
+   ::button-color              color-white
+   ::button-disabled-bg        "#8c95a0"
+   ::button-disabled-color     "#ccc"
 
-   ::menu-bg                 color-white
-   ::menu-header-bg          color-dark-grey
-   ::menu-header-color       color-white
-   ::menu-arrow-bg           color-dark-grey
+   ::menu-bg                   color-white
+   ::menu-header-bg            color-dark-grey
+   ::menu-header-color         color-white
+   ::menu-arrow-bg             color-dark-grey
 
-   ::tab-active-bg           color-white
-   ::tab-bg                  color-iron
-   ::tab-text                color-limed-spruce
-   ::tab-border              color-geyser
-   ::tab-text-field-bg       "transparent"
-   ::tab-text-field-focus-bg color-white
+   ::tab-active-bg             color-white
+   ::tab-bg                    color-iron
+   ::tab-text                  color-limed-spruce
+   ::tab-border                color-geyser
+   ::tab-text-field-bg         "transparent"
+   ::tab-text-field-focus-bg   color-white
 
-   ::workspace-bg            "#9fa2ab"
-   ::workspace-tools-bg      color-white
-   ::workspace-tools-color   color-limed-spruce
+   ::workspace-bg              "#9fa2ab"
+   ::workspace-tools-bg        color-white
+   ::workspace-tools-color     color-limed-spruce
 
-   ::card-bg                 color-white
-   ::card-header-bg          color-mystic
-   ::card-header-text        color-limed-spruce
-   ::card-ellipsis-menu-bg   color-mystic
-   ::card-toolbar-bg         color-geyser
-   ::card-default-text       "#000"
+   ::card-bg                   color-white
+   ::card-header-bg            color-mystic
+   ::card-header-text          color-limed-spruce
+   ::card-ellipsis-menu-bg     color-mystic
+   ::card-toolbar-bg           color-geyser
+   ::card-toolbar-default-text color-limed-spruce
+   ::card-default-text         "#000"
 
-   ::welcome-msg-bg          color-dark-grey
+   ::welcome-msg-bg            color-dark-grey
 
-   ::help-dialog-bg          "rgba(0, 0, 0, 0.8)"})
+   ::help-dialog-bg            "rgba(0, 0, 0, 0.8)"})
 
 (def dark-colors
-  {::bg                      "#212121"
-   ::primary-text-color      "#fafafa"
-   ::error-text-color        "#EF5350"
+  {::bg                        "#212121"
+   ::primary-text-color        "#fafafa"
+   ::error-text-color          "#EF5350"
 
-   ::button-bg               "rgb(138, 5, 190)"
-   ::button-color            color-white
-   ::button-disabled-bg      "#8c95a0"
-   ::button-disabled-color   "#ccc"
+   ::button-bg                 "rgb(138, 5, 190)"
+   ::button-color              color-white
+   ::button-disabled-bg        "#8c95a0"
+   ::button-disabled-color     "#ccc"
 
-   ::menu-bg                 "#212121"
-   ::menu-header-bg          "#616161"
-   ::menu-header-color       color-white
-   ::menu-arrow-bg           "#616161"
+   ::menu-bg                   "#212121"
+   ::menu-header-bg            "#616161"
+   ::menu-header-color         color-white
+   ::menu-arrow-bg             "#616161"
 
-   ::tab-active-bg           "#212121"
-   ::tab-bg                  "#212121"
-   ::tab-text                "#fafafa"
-   ::tab-border              "#616161"
-   ::tab-text-field-bg       "transparent"
-   ::tab-text-field-focus-bg "#616161"
+   ::tab-active-bg             "#212121"
+   ::tab-bg                    "#212121"
+   ::tab-text                  "#fafafa"
+   ::tab-border                "#616161"
+   ::tab-text-field-bg         "transparent"
+   ::tab-text-field-focus-bg   "#616161"
 
-   ::workspace-bg            "#212121"
-   ::workspace-tools-bg      "#424242"
-   ::workspace-tools-color   "#fafafa"
+   ::workspace-bg              "#212121"
+   ::workspace-tools-bg        "#424242"
+   ::workspace-tools-color     "#fafafa"
 
-   ::card-bg                 color-white
-   ::card-header-bg          "#424242"
-   ::card-header-text        "#fafafa"
-   ::card-ellipsis-menu-bg   "#424242"
-   ::card-toolbar-bg         color-geyser
-   ::card-default-text       "#000"
+   ::card-bg                   color-white
+   ::card-header-bg            "#424242"
+   ::card-header-text          "#fafafa"
+   ::card-ellipsis-menu-bg     "#424242"
+   ::card-toolbar-bg           color-geyser
+   ::card-toolbar-default-text "#000"
+   ::card-default-text         "#000"
 
-   ::welcome-msg-bg          color-dark-grey
+   ::welcome-msg-bg            color-dark-grey
 
-   ::help-dialog-bg          "rgba(0, 0, 0, 0.8)"})
+   ::help-dialog-bg            "rgba(0, 0, 0, 0.8)"})
 
 (defn color [color-name]
   (get dark-colors color-name))

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -136,6 +136,8 @@
 
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
+(def default-theme :theme/light)
+
 (def theme-name->colors-map
   {:theme/light classical-colors
    :theme/dark  dark-colors})

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -146,9 +146,9 @@
   (local-storage/get ::theme :theme/light))
 
 (defn color [color-name]
-  (let [theme (if (= user-defined-theme :theme/auto)
-                (if (gobj/get (js/matchMedia "(prefers-color-scheme: dark)") "matches") :theme/dark :theme/light)
-                user-defined-theme)
+  (let [theme      (if (= user-defined-theme :theme/auto)
+                     (if (gobj/get (js/matchMedia "(prefers-color-scheme: dark)") "matches") :theme/dark :theme/light)
+                     user-defined-theme)
         colors-map (get theme-name->colors-map theme)]
     (get colors-map color-name)))
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -131,7 +131,7 @@
    ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
 (defn color [color-name]
-  (get dark-colors color-name))
+  (get classical-colors color-name))
 
 (def card-border-radius "6px")
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -65,7 +65,7 @@
    ::primary-text-color        "#fafafa"
    ::error-text-color          "#EF5350"
 
-   ::button-bg                 "rgb(138, 5, 190)"
+   ::button-bg                 "#546E7A"
    ::button-color              color-white
    ::button-disabled-bg        "#8c95a0"
    ::button-disabled-color     "#ccc"

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -75,10 +75,10 @@
    ::menu-header-color         color-white
    ::menu-arrow-bg             "#616161"
 
-   ::tab-active-bg             "#212121"
+   ::tab-active-bg             "#424242"
    ::tab-bg                    "#212121"
    ::tab-text                  "#fafafa"
-   ::tab-border                "#616161"
+   ::tab-border                "#424242"
    ::tab-text-field-bg         "transparent"
    ::tab-text-field-focus-bg   "#616161"
 

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -23,90 +23,108 @@
 (def color-iron "#e7e8e9")
 
 (def classical-colors
-  {::color-scheme              "light"
+  {::color-scheme                    "light"
 
-   ::bg                        color-white
-   ::primary-text-color        "#000"
-   ::error-text-color          "#ef0000"
+   ::bg                              color-white
+   ::primary-text-color              "#000"
+   ::error-text-color                "#ef0000"
 
-   ::button-bg                 color-fiord
-   ::button-active-bg          color-fiord
-   ::button-color              color-white
-   ::button-disabled-bg        "#8c95a0"
-   ::button-disabled-color     "#ccc"
+   ::button-bg                       color-fiord
+   ::button-active-bg                color-fiord
+   ::button-color                    color-white
+   ::button-disabled-bg              "#8c95a0"
+   ::button-disabled-color           "#ccc"
 
-   ::menu-bg                   color-white
-   ::menu-header-bg            color-dark-grey
-   ::menu-header-color         color-white
-   ::menu-arrow-bg             color-dark-grey
+   ::menu-bg                         color-white
+   ::menu-header-bg                  color-dark-grey
+   ::menu-header-color               color-white
+   ::menu-arrow-bg                   color-dark-grey
 
-   ::tab-active-bg             color-white
-   ::tab-bg                    color-iron
-   ::tab-text                  color-limed-spruce
-   ::tab-border                color-geyser
-   ::tab-text-field-bg         "transparent"
-   ::tab-text-field-focus-bg   color-white
+   ::tab-active-bg                   color-white
+   ::tab-bg                          color-iron
+   ::tab-text                        color-limed-spruce
+   ::tab-border                      color-geyser
+   ::tab-text-field-bg               "transparent"
+   ::tab-text-field-focus-bg         color-white
 
-   ::workspace-bg              "#9fa2ab"
-   ::workspace-tools-bg        color-white
-   ::workspace-tools-color     color-limed-spruce
+   ::workspace-bg                    "#9fa2ab"
+   ::workspace-tools-bg              color-white
+   ::workspace-tools-color           color-limed-spruce
 
-   ::card-default-color-scheme "light"
-   ::card-bg                   color-white
-   ::card-default-text         "#000"
-   ::card-toolbar-bg           color-geyser
-   ::card-toolbar-default-text color-limed-spruce
-   ::card-toolbar-more-actions "#000"
-   ::card-header-bg            color-mystic
-   ::card-header-text          color-limed-spruce
-   ::card-ellipsis-menu-bg     color-mystic
+   ::card-default-color-scheme       "light"
+   ::card-bg                         color-white
+   ::card-default-text               "#000"
+   ::card-toolbar-bg                 color-geyser
+   ::card-toolbar-default-text       color-limed-spruce
+   ::card-toolbar-more-actions       "#000"
+   ::card-header-bg                  color-mystic
+   ::card-header-text                color-limed-spruce
+   ::card-ellipsis-menu-bg           color-mystic
 
-   ::welcome-msg-bg            color-dark-grey
+   ::spotlight-bg                    "#e2e2e2"
+   ::spotlight-search-field-bg       "#cccbcd"
+   ::spotlight-search-text           "#000"
+   ::spotlight-option-text           "#1d1d1d"
+   ::spotlight-option-highlight-bg   "#e2d610"
+   ::spotlight-option-highlight-text "#000"
+   ::spotlight-option-selected-bg    "#582074"
+   ::spotlight-option-selected-text  color-white
 
-   ::help-dialog-bg            "rgba(0, 0, 0, 0.8)"})
+   ::welcome-msg-bg                  color-dark-grey
+
+   ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
 (def dark-colors
-  {::color-scheme              "dark"
+  {::color-scheme                    "dark"
 
-   ::bg                        "#202124"
-   ::primary-text-color        "#fafafa"
-   ::error-text-color          "#CF6679"
+   ::bg                              "#202124"
+   ::primary-text-color              "#fafafa"
+   ::error-text-color                "#CF6679"
 
-   ::button-bg                 "#546E7A"
-   ::button-active-bg          "#455A64"
-   ::button-color              color-white
-   ::button-disabled-bg        "#8c95a0"
-   ::button-disabled-color     "#ccc"
+   ::button-bg                       "#546E7A"
+   ::button-active-bg                "#455A64"
+   ::button-color                    color-white
+   ::button-disabled-bg              "#8c95a0"
+   ::button-disabled-color           "#ccc"
 
-   ::menu-bg                   "#202124"
-   ::menu-header-bg            "#3f4043"
-   ::menu-header-color         color-white
-   ::menu-arrow-bg             "#3f4043"
+   ::menu-bg                         "#202124"
+   ::menu-header-bg                  "#3f4043"
+   ::menu-header-color               color-white
+   ::menu-arrow-bg                   "#3f4043"
 
-   ::tab-active-bg             "#3f4043"
-   ::tab-bg                    "#202124"
-   ::tab-text                  "#fafafa"
-   ::tab-border                "#3f4043"
-   ::tab-text-field-bg         "transparent"
-   ::tab-text-field-focus-bg   "#616161"
+   ::tab-active-bg                   "#3f4043"
+   ::tab-bg                          "#202124"
+   ::tab-text                        "#fafafa"
+   ::tab-border                      "#3f4043"
+   ::tab-text-field-bg               "transparent"
+   ::tab-text-field-focus-bg         "#616161"
 
-   ::workspace-bg              "#202124"
-   ::workspace-tools-bg        "#3f4043"
-   ::workspace-tools-color     "#fafafa"
+   ::workspace-bg                    "#202124"
+   ::workspace-tools-bg              "#3f4043"
+   ::workspace-tools-color           "#fafafa"
 
-   ::card-default-color-scheme "light"
-   ::card-bg                   color-white
-   ::card-default-text         "#000"
-   ::card-toolbar-bg           color-geyser
-   ::card-toolbar-default-text "#000"
-   ::card-toolbar-more-actions "#fafafa"
-   ::card-header-bg            "#3f4043"
-   ::card-header-text          "#fafafa"
-   ::card-ellipsis-menu-bg     "#3f4043"
+   ::card-default-color-scheme       "light"
+   ::card-bg                         color-white
+   ::card-default-text               "#000"
+   ::card-toolbar-bg                 color-geyser
+   ::card-toolbar-default-text       "#000"
+   ::card-toolbar-more-actions       "#fafafa"
+   ::card-header-bg                  "#3f4043"
+   ::card-header-text                "#fafafa"
+   ::card-ellipsis-menu-bg           "#3f4043"
 
-   ::welcome-msg-bg            color-dark-grey
+   ::spotlight-bg                    "#202124"
+   ::spotlight-search-field-bg       "#3f4043"
+   ::spotlight-search-text           "#fafafa"
+   ::spotlight-option-text           "#fafafa"
+   ::spotlight-option-highlight-bg   "#FFF59D"
+   ::spotlight-option-highlight-text "#000"
+   ::spotlight-option-selected-bg    "#546E7A"
+   ::spotlight-option-selected-text  "#fafafa"
 
-   ::help-dialog-bg            "rgba(0, 0, 0, 0.8)"})
+   ::welcome-msg-bg                  color-dark-grey
+
+   ::help-dialog-bg                  "rgba(0, 0, 0, 0.8)"})
 
 (defn color [color-name]
   (get dark-colors color-name))

--- a/src/nubank/workspaces/ui/core.cljs
+++ b/src/nubank/workspaces/ui/core.cljs
@@ -83,7 +83,8 @@
    ::test-header-waiting-bg          color-yellow
    ::test-header-running-bg          color-yellow
    ::test-header-success-bg          color-mint-green
-   ::test-header-error-bg            color-red-dark})
+   ::test-header-error-bg            color-red-dark
+   ::test-header-disabled-bg         color-light-grey})
 
 (def dark-colors
   {::color-scheme                    "dark"
@@ -144,7 +145,8 @@
    ::test-header-waiting-bg          "#3f4043"
    ::test-header-running-bg          "#3f4043"
    ::test-header-success-bg          "#388E3C"
-   ::test-header-error-bg            "#BF360C"})
+   ::test-header-error-bg            "#BF360C"
+   ::test-header-disabled-bg         "#333333"})
 
 (def default-theme :theme/light)
 

--- a/src/nubank/workspaces/ui/grid_layout.cljs
+++ b/src/nubank/workspaces/ui/grid_layout.cljs
@@ -7,8 +7,8 @@
             [nubank.workspaces.ui.core :as uc]))
 
 (def column-size 120)
-(def max-columns 20)
-(def columns-step 2)
+(def max-columns 18)
+(def columns-step 1)
 
 (def breakpoints
   (vec

--- a/src/nubank/workspaces/ui/grid_layout.cljs
+++ b/src/nubank/workspaces/ui/grid_layout.cljs
@@ -7,8 +7,8 @@
             [nubank.workspaces.ui.core :as uc]))
 
 (def column-size 120)
-(def max-columns 18)
-(def columns-step 1)
+(def max-columns 20)
+(def columns-step 2)
 
 (def breakpoints
   (vec
@@ -101,12 +101,12 @@
    :componentDidMount (fn []
                         (let [{:keys [onBreakpointChange]} (fp/props this)
                               width (-> (gobj/getValueByKeys this "grid")
-                                        (dom/node)
-                                        (gobj/get "offsetWidth"))
+                                      (dom/node)
+                                      (gobj/get "offsetWidth"))
                               bp    (->> (rseq breakpoints)
-                                         (filter #(>= width (:breakpoint %)))
-                                         first
-                                         :id)]
+                                      (filter #(>= width (:breakpoint %)))
+                                      first
+                                      :id)]
                           (onBreakpointChange bp)))}
   (dom/create-element GridWithWidth (clj->js (assoc props :ref #(gobj/set this "grid" %)))
     (fp/children this)))

--- a/src/nubank/workspaces/ui/grid_layout.cljs
+++ b/src/nubank/workspaces/ui/grid_layout.cljs
@@ -101,12 +101,12 @@
    :componentDidMount (fn []
                         (let [{:keys [onBreakpointChange]} (fp/props this)
                               width (-> (gobj/getValueByKeys this "grid")
-                                      (dom/node)
-                                      (gobj/get "offsetWidth"))
+                                        (dom/node)
+                                        (gobj/get "offsetWidth"))
                               bp    (->> (rseq breakpoints)
-                                      (filter #(>= width (:breakpoint %)))
-                                      first
-                                      :id)]
+                                         (filter #(>= width (:breakpoint %)))
+                                         first
+                                         :id)]
                           (onBreakpointChange bp)))}
   (dom/create-element GridWithWidth (clj->js (assoc props :ref #(gobj/set this "grid" %)))
     (fp/children this)))

--- a/src/nubank/workspaces/ui/modal.cljs
+++ b/src/nubank/workspaces/ui/modal.cljs
@@ -70,7 +70,7 @@
                                 :align-items     "center"
                                 :justify-content "center"
                                 :z-index         "100"
-                                :overflow-y      "scroll"}]
+                                :overflow-y      "auto"}]
                  [:.container {:display        "flex"
                                :flex-direction "column"
                                :max-width      "90vw"

--- a/src/nubank/workspaces/ui/spotlight.cljs
+++ b/src/nubank/workspaces/ui/spotlight.cljs
@@ -68,7 +68,7 @@
 (fp/defsc SpotlightEntry
   [this {::keys [opt value on-change on-select]}]
   {:css [[:.option
-          {:color         "#1d1d1d"
+          {:color         (uc/color ::uc/spotlight-option-text)
            :cursor        "pointer"
            :font-size     "16px"
            :padding       "2px 3px"
@@ -77,16 +77,16 @@
            :text-overflow "ellipsis"}
 
           [:b
-           {:background "#e2d610"
-            :color      "#000"}]]
+           {:background (uc/color ::uc/spotlight-option-highlight-bg)
+            :color      (uc/color ::uc/spotlight-option-highlight-text)}]]
 
          [:.option-type
           {:font-size  "11px"
            :font-style "italic"}]
 
          [:.option-selected
-          {:background "#582074"
-           :color      "#fff"}]
+          {:background (uc/color ::uc/spotlight-option-selected-bg)
+           :color      (uc/color ::uc/spotlight-option-selected-text)}]
 
          [:.solo-hint
           {:display "none"}]
@@ -126,16 +126,16 @@
                            {:height "600px"}]
 
                           [:.container
-                           {:background    "#e2e2e2"
+                           {:background    (uc/color ::uc/spotlight-bg)
                             :border-radius "3px"
                             :box-shadow    "0 6px 6px rgba(0, 0, 0, 0.26), 0 10px 20px rgba(0, 0, 0, 0.19), 0 0 2px rgba(0,0,0,0.3)"
                             :padding       "10px"}]
 
                           [:.search
-                           {:background  "#cccbcd"
+                           {:background  (uc/color ::uc/spotlight-search-field-bg)
                             :border      "0"
                             :box-sizing  "border-box"
-                            :color       "#000"
+                            :color       (uc/color ::uc/spotlight-search-text)
                             :font-family uc/font-helvetica
                             :font-size   "32px"
                             :outline     "0"

--- a/src/nubank/workspaces/ui/spotlight.cljs
+++ b/src/nubank/workspaces/ui/spotlight.cljs
@@ -127,6 +127,7 @@
 
                           [:.container
                            {:background    (uc/color ::uc/spotlight-bg)
+                            :color-scheme  (uc/color ::uc/color-scheme)
                             :border-radius "3px"
                             :box-shadow    "0 6px 6px rgba(0, 0, 0, 0.26), 0 10px 20px rgba(0, 0, 0, 0.19), 0 0 2px rgba(0,0,0,0.3)"
                             :padding       "10px"}]


### PR DESCRIPTION
### Changes (as usual no breaking changes)

* Align items following a 10px baseline grid
* Add functional color names
* Add theme change functionality
* Fix tab text field issue where the cursor stays on the left of the tab name
* Bump shadow-cljs

Dark mode:
![image](https://user-images.githubusercontent.com/4316501/109437037-9a775580-7a01-11eb-829c-0af083ee43de.png)
Dark mode tests:
![image](https://user-images.githubusercontent.com/4316501/109442123-0e235d80-7a16-11eb-9c52-db77f669d7e1.png)
Light mode:
![image](https://user-images.githubusercontent.com/4316501/109437330-20e06700-7a03-11eb-8914-73c24fbfa776.png)
Theme selector:
![image](https://user-images.githubusercontent.com/4316501/109437307-073f1f80-7a03-11eb-876d-ce8eb5bd6dc9.png)


### Notes

The default theme will continue to be `light`.

Even in dark mode the cards will continue to use css color-scheme light. This avoids people being caught by surprise if they forgot to define their font-color and suddenly their components start to use a white colored font. Basically the cards will behave like in light theme even when dark theme is selected.