### PR TITLE
Export clj-kondo lint config

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:config-paths ["com.fulcrologic/fulcro"
+                "../resources/clj-kondo.exports/nubank/workspaces"]}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ node_modules
 /examples/workspaces-shadow-example/resources/target
 .idea
 *.iml
+.lsp/.cache
+.clj-kondo/.cache

--- a/resources/clj-kondo.exports/nubank/workspaces/config.edn
+++ b/resources/clj-kondo.exports/nubank/workspaces/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {nubank.workspaces.core/defcard clojure.core/def
+           nubank.workspaces.core/defworkspace clojure.core/def
+           nubank.workspaces.core/if-cljs clojure.core/if
+           nubank.workspaces.core/deftest clojure.test/deftest}}


### PR DESCRIPTION
This will make any client of this library aware of workspaces macros, just needing to add:
`.clj-kondo/config.edn`
```
{:config-paths ["nubank/workspaces"]}
```

[REF](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration)